### PR TITLE
Correct path for node_modules inside the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ HEALTHCHECK CMD curl -fs http://localhost:$PORT/healthz || exit 1
 WORKDIR /usr/src
 COPY package.json /usr/src/
 RUN npm install && npm cache clean
-ENV PATH /data/node_modules/.bin:$PATH
+ENV PATH /usr/src/node_modules/.bin:$PATH
 
 # copy in our source code last, as it changes the most
 WORKDIR /usr/src/app


### PR DESCRIPTION
Currently, the path added to the `PATH` environment variable is one that doesn't exist. This should probably be `/usr/src/node_modules/.bin`, which is the one of the Node modules we're installing in the image.