### PR TITLE
Adopt Filesystem Hierarchy Standard

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             "sourceMaps": false,
             "outFiles": [],
             "localRoot": "${workspaceRoot}",
-            "remoteRoot": "/usr/src/app"
+            "remoteRoot": "/opt/app"
         }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # if you're doing anything beyond your local machine, please pin this to a specific version at https://hub.docker.com/_/node/
 FROM node:6
 
-RUN mkdir -p /usr/src/app
+RUN mkdir -p /opt/app
 
 # set our node environment, either development or production
 # defaults to production, compose overrides this to development on build and run
@@ -17,14 +17,14 @@ EXPOSE $PORT 5858 9229
 HEALTHCHECK CMD curl -fs http://localhost:$PORT/healthz || exit 1
 
 # install dependencies first, in a different location for easier app bind mounting for local development
-WORKDIR /usr/src
-COPY package.json /usr/src/
+WORKDIR /opt
+COPY package.json /opt
 RUN npm install && npm cache clean
-ENV PATH /usr/src/node_modules/.bin:$PATH
+ENV PATH /opt/node_modules/.bin:$PATH
 
 # copy in our source code last, as it changes the most
-WORKDIR /usr/src/app
-COPY . /usr/src/app
+WORKDIR /opt/app
+COPY . /opt/app
 
 # if you want to use npm start instead, then use `docker run --init in production`
 # so that signals are passed properly. Note the code in index.js is needed to catch Docker signals

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "5858:5858"
       - "9229:9229"
     volumes:
-      - .:/usr/src/app
+      - .:/opt/app
     environment:
       - NODE_ENV=development
 


### PR DESCRIPTION
According to the Filesystem Hierarchy Standard (http://www.pathname.com/fhs/) which is, generally, followed by Linux distributions /usr/src should only be used for reference source code. Applications should instead be installed under /opt/<package>.