### PR TITLE
Fix debugging for docker for mac

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,9 @@
             "type": "node",
             "request": "attach",
             "protocol": "inspector",
-            "port": 9229
+            "port": 9229,
+            "localRoot": "${workspaceRoot}",
+            "remoteRoot": "/opt/app"
         },
         {
             "name": "Attach 5858 --debug",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # if you're doing anything beyond your local machine, please pin this to a specific version at https://hub.docker.com/_/node/
-FROM node:7
+FROM node:6
 
 RUN mkdir -p /opt/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # if you're doing anything beyond your local machine, please pin this to a specific version at https://hub.docker.com/_/node/
-FROM node:6
+FROM node:7
 
 RUN mkdir -p /opt/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       args:
         - NODE_ENV=development
     # you can use standard debug config or experimental node inspect
-    command: node --debug=5858 ../node_modules/nodemon/bin/nodemon.js
-    #command: node --inspect ../node_modules/nodemon/bin/nodemon.js
+    command: ../node_modules/.bin/nodemon --debug=0.0.0.0:5858
+    #command: ../node_modules/.bin/nodemon --inspect=0.0.0.0:9229
     ports:
       - "80:80"
       - "5858:5858"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: .
       args:
         - NODE_ENV=development
-    # you can use standard debug config or experimental node inspect
-    command: ../node_modules/.bin/nodemon --debug=0.0.0.0:5858
-    #command: ../node_modules/.bin/nodemon --inspect=0.0.0.0:9229
+    # you can use legacy debug config or new inspect
+    #command: ../node_modules/.bin/nodemon --debug=0.0.0.0:5858
+    command: ../node_modules/.bin/nodemon --inspect=0.0.0.0:9229
     ports:
       - "80:80"
       - "5858:5858"


### PR DESCRIPTION
I think this will resolve your issues with:

https://github.com/BretFisher/node-docker-good-defaults/issues/4
https://github.com/BretFisher/node-docker-good-defaults/issues/6

First the problem on mac is that the localhost (127.0.0.1) is not working due to some restrictions. 

Watch it here: https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds

The second part was that the the node 6 is not available to server inspector on host 0.0.0.0 this was solved in 7.15 i believe you can follow this thread: https://github.com/nodejs/node/issues/11591 

On the end I was struggling with exposing for source files that were exposing for me in the devtool only the `node-modules`. So I came up with the change of command 

```
command: ../node_modules/.bin/nodemon --inspect=0.0.0.0:9229
```

But maybe you will spot some issues with that solution, if yes keep me updated.

Last thing I fixed the .vscode lunch config to map correct paths.

Hope this would help. For me it is working. Thank you for your awesome work.