### PR TITLE
Do not allow host node_modules to be mounted on container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "9229:9229"
     volumes:
       - .:/opt/app
+      - /opt/app/node_modules
     environment:
       - NODE_ENV=development
 


### PR DESCRIPTION
In some cases, a local `npm install` is required to set project tools such as testing libs and linting lib/configs. Of course the developer can install it globally but sometimes the project have specific eslint libs, for example, and it is quite annoying to install one-by-one globally.

To avoid the local node_modules to be mounted on the container, a simple `- /opt/app/node_modules` was added to the docker-compose volumes section.