### PR TITLE
Use pure Node.js healthcheck implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,14 @@ ARG PORT=80
 ENV PORT $PORT
 EXPOSE $PORT 5858 9229
 
-# check every 30s to ensure this service returns HTTP 200
-HEALTHCHECK CMD curl -fs http://localhost:$PORT/healthz || exit 1
-
 # install dependencies first, in a different location for easier app bind mounting for local development
 WORKDIR /opt
 COPY package.json package-lock.json* ./
 RUN npm install && npm cache clean --force
 ENV PATH /opt/node_modules/.bin:$PATH
+
+# check every 30s to ensure this service returns HTTP 200
+HEALTHCHECK --interval=30s CMD node healthcheck.js
 
 # copy in our source code last, as it changes the most
 WORKDIR /opt/app

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,0 +1,21 @@
+var http = require("http");
+
+var options = {
+  timeout: 2000,
+  host: 'localhost',
+  port: process.env.PORT || 8080,
+  path: '/healthz' // must be the same as HEALTHCHECK in Dockerfile
+};
+
+var request = http.request(options, (res) => {
+  console.info('STATUS: ' + res.statusCode);
+  process.exitCode = (res.statusCode === 200) ? 0 : 1;
+  process.exit();
+});
+
+request.on('error', function(err) {
+  console.error('ERROR', err);
+  process.exit(1);
+});
+
+request.end();


### PR DESCRIPTION
Why? Some Docker Node images do not have `curl` installed. Also pure JS
implementation gives much more power to the user.

Moved HEALTHCHECK down in Dockerfile, because `healthcheck.js` is part
of the application code currently.