### PR TITLE
Add unit-tests and better integration with VisualStudio Code (vscode)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,17 +11,15 @@
             "remoteRoot": "/opt/app"
         },
         {
-            "name": "Attach 5858 --debug",
+            "name": "Docker Test (Attach 9230 --inspect)",
             "type": "node",
             "request": "attach",
-            "protocol": "legacy",
-            "port": 5858,
-            "address": "localhost",
-            "restart": false,
-            "sourceMaps": false,
-            "outFiles": [],
+            "protocol": "inspector",
+            "port": 9230,
             "localRoot": "${workspaceRoot}",
-            "remoteRoot": "/opt/app"
+            "remoteRoot": "/opt/app",
+            "preLaunchTask": "Docker npm run test-wait-debuger", // See ./tasks.json
+            "internalConsoleOptions": "openOnSessionStart"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,60 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      // Execute command in docker
+      "label": "Docker npm test",
+      "type": "shell",
+      "command": "docker-compose exec node npm test",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
+    },
+    {
+      // Execute command in docker
+      "label": "Docker npm run test-watch",
+      "type": "shell",
+      "command": "docker-compose exec node npm run test-watch",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
+    },
+    {
+      // Execute command in docker
+      // This task is use as preLaunchTask of launch (Remote Debuging Attach)
+      // This will execute 2 things:
+      //  -Kill previous process, to make sure we restart debug from start
+      //   --use pkill with cmd process argument match, in this case "0.0.0.0:9230"
+      //  -Start start test and wait for debugger, see test-wait-debuger in package.json
+      "label": "Docker npm run test-wait-debuger",
+      "type": "shell",
+      "command": "docker-compose exec node pkill -c --oldest --full \"0.0.0.0:9230\"; docker-compose exec -d node npm run test-wait-debuger",
+      "windows": {
+        "command": "docker-compose exec node pkill -c --oldest --full \"0.0.0.0:9230\"& docker-compose exec -d node npm run test-wait-debuger"
+      },
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
+    },
+    {
+      // Execute command in docker
+      "label": "Docker terminal in container (bash)",
+      "type": "shell",
+      "command": "docker-compose exec node bash",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "focus": true
+      }
+    },
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN mkdir -p /opt/app
 ARG NODE_ENV=production
 ENV NODE_ENV $NODE_ENV
 
-# default to port 80 for node, and 5858 or 9229 for debug
+# default to port 80 for node, and 9229 and 9230 (tests) for debug
 ARG PORT=80
 ENV PORT $PORT
-EXPOSE $PORT 5858 9229
+EXPOSE $PORT 9229 9230
 
 # check every 30s to ensure this service returns HTTP 200
 HEALTHCHECK CMD curl -fs http://localhost:$PORT/healthz || exit 1

--- a/README.md
+++ b/README.md
@@ -37,12 +37,19 @@ If this was your Node.js app, to start local development you would:
 
  - Running `docker-compose up` is all you need. It will:
  - Build custom local image enabled for development (nodemon, `NODE_ENV=development`).
- - Start container from that image with ports 80, 5858, and 9229 open (on localhost).
+ - Start container from that image with ports 80 and 9229 open (on localhost).
  - Starts with `nodemon` to restart node on file change in host pwd.
  - Mounts the pwd to the app dir in container.
  - If you need other services like databases, just add to compose file and they'll be added to the custom Docker network for this app on `up`.
  - Compose should detect if you need to rebuild due to changed package.json or Dockerfile, but `docker-compose build` works for manually building.
  - Be sure to use `docker-compose down` to cleanup after your done dev'ing.
+
+To execute the unit-tests, you would:
+ - Execute `docker-compose exec node npm test`, It will:
+ - Run a process `npm test` in the container node.
+ - You can use the *vscode* to debug unit-tests with config `Docker Test (Attach 9230 --inspect)`, It will:
+   - Start a debugging process in the container and wait-for-debugger, this is done by *vscode tasks*
+   - It will also kill previous debugging process if existing.
 
 ### Other Resources
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
     command: ../node_modules/.bin/nodemon --inspect=0.0.0.0:9229
     ports:
       - "80:80"
-      - "5858:5858"
       - "9229:9229"
+      - "9230:9230"
     volumes:
       - .:/opt/app:delegated
       # this is a workaround to prevent host node_modules from accidently getting mounted in container

--- a/index.js
+++ b/index.js
@@ -75,3 +75,4 @@ function shutdown() {
 // need above in docker container to properly exit
 //
 
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -8,13 +8,22 @@
   "scripts": {
     "start": "node index.js",
     "dev-docker": "../node_modules/nodemon/bin/nodemon.js --debug=5858",
-    "dev-host": "nodemon --debug=5858"
+    "dev-host": "nodemon --debug=5858",
+    "start-watch": "nodemon index.js --inspect=0.0.0.0:9229",
+    "start-wait-debuger": "nodemon index.js --inspect-brk=0.0.0.0:9229",
+    "test": "cross-env NODE_ENV=test PORT=8081 mocha --timeout 10000 --exit --inspect=0.0.0.0:9230",
+    "test-watch": "nodemon --exec \"npm test\"",
+    "test-wait-debuger": "cross-env NODE_ENV=test PORT=8081 mocha --no-timeouts --exit --inspect-brk=0.0.0.0:9230"
   },
   "dependencies": {
     "express": "^4.14.1",
     "morgan": "^1.8.1"
   },
   "devDependencies": {
+    "chai": "^4.1.2",
+    "chai-http": "^4.0.0",
+    "cross-env": "^5.1.4",
+    "mocha": "^5.0.5",
     "nodemon": "^1.11.0"
   }
 }

--- a/test/sample.js
+++ b/test/sample.js
@@ -1,0 +1,32 @@
+const app = require('../index');
+
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+
+chai.use(chaiHttp);
+chai.should();
+
+describe('API /healthz', () => {
+    it('it should return 200', (done) => {
+        chai.request(app)
+            .get('/healthz')
+            .end((err, res) => {
+                res.should.have.status(200);
+                done();
+            });
+    });
+});
+
+describe('API /', () => {
+    it('it should return Welcome message', (done) => {
+        chai.request(app)
+            .get('/')
+            .end((err, res) => {
+                res.should.have.status(200);
+                res.should.to.be.html;
+                res.text.should.be.equal("Hello Docker World\n");
+                done();
+            });
+    });
+});
+


### PR DESCRIPTION
 - Add possibility to debug unit-tests, config: `Docker Test (Attach 9230 --inspect)`
   - Start a debugging process in the container and wait-for-debugger, this is done by *vscode tasks*
   - It will also kill previous debugging process if existing.
 - Add some tasks (see .vscode/tasks.json):
   - Execute test `Docker npm test`
   - Execute test with watcher `Docker npm run test-watch`
   - Execute test and wait for debbuger `Docker npm run test-wait-debuger`
   - Get a terminal in node container `Docker terminal in container (bash)`

All of this is compatible with unix/windows