### PR TITLE
Move startup scripts to bin/www

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ COPY . /opt/app
 # so that signals are passed properly. Note the code in index.js is needed to catch Docker signals
 # using node here is still more graceful stopping then npm with --init afaik
 # I still can't come up with a good production way to run with npm and graceful shutdown
-CMD [ "node", "index.js" ]
+CMD [ "node", "bin/www" ]

--- a/bin/www
+++ b/bin/www
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+const app = require("../index");
+const debug = require("debug")("server:server");
+const http = require("http");
+
+/**
+ * Constants
+ */
+
+const PORT = process.env.PORT || 8080;
+// if you're not using docker-compose for local development, this will default to 8080
+// to prevent non-root permission problems with 80. Dockerfile is set to make this 80
+// because containers don't have that issue :)
+
+app.set("port", PORT);
+
+/**
+ * Create HTTP server.
+ */
+
+const server = http.createServer(app);
+
+/**
+ * Listen on provided port, on all network interfaces.
+ */
+
+server.listen(PORT);
+server.on("error", onError);
+server.on("listening", onListening);
+
+
+/**
+ * need this in docker container to properly exit since node doesn't handle SIGINT/SIGTERM
+ * this also won't work on using npm start since:
+ * https://github.com/npm/npm/issues/4603
+ * https://github.com/npm/npm/pull/10868
+ * https://github.com/RisingStack/kubernetes-graceful-shutdown-example/blob/master/src/index.js
+ * if you want to use npm then start with `docker run --init` to help, but I still don't think it's
+ * a graceful shutdown of node process
+ * 
+ * quit on ctrl-c when running docker in terminal
+ */
+
+process.on('SIGINT', function onSigint () {
+	console.info('Got SIGINT (aka ctrl-c in docker). Graceful shutdown ', new Date().toISOString());
+  shutdown();
+});
+
+// quit properly on docker stop
+process.on('SIGTERM', function onSigterm () {
+  console.info('Got SIGTERM (docker container stop). Graceful shutdown ', new Date().toISOString());
+  shutdown();
+})
+
+// shut down server
+function shutdown() {
+  server.close(function onServerClosed (err) {
+    if (err) {
+      console.error(err);
+      process.exitCode = 1;
+		}
+		process.exit();
+  })
+}
+
+/**
+ * Event listener for HTTP server "error" event.
+ */
+
+function onError(error) {
+  if (error.syscall !== "listen") {
+    throw error;
+  }
+
+  const bind = typeof port === "string" ? "Pipe " + port : "Port " + port;
+
+  // handle specific listen errors with friendly messages
+  switch (error.code) {
+    case "EACCES":
+      console.error(bind + " requires elevated privileges");
+      process.exit(1);
+      break;
+    case "EADDRINUSE":
+      console.error(bind + " is already in use");
+      process.exit(1);
+      break;
+    default:
+      throw error;
+  }
+}
+
+/**
+ * Event listener for HTTP server "listening" event.
+ */
+
+function onListening() {
+  const addr = server.address();
+  const bind = typeof addr === "string" ? "pipe " + addr : "port " + addr.port;
+  debug("Listening on " + bind);
+
+  console.log("Server listenning on port:", addr.port);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     # which has trouble seeing file changes, so add -L to use legacy polling
     # https://github.com/remy/nodemon#application-isnt-restarting
     #command: ../node_modules/.bin/nodemon --debug=0.0.0.0:5858
-    command: ../node_modules/.bin/nodemon --inspect=0.0.0.0:9229
+    command: ../node_modules/.bin/nodemon bin/www --inspect=0.0.0.0:9229
     ports:
       - "80:80"
       - "9229:9229"

--- a/index.js
+++ b/index.js
@@ -12,12 +12,6 @@ var morgan = require('morgan');
 // which is a best practice in Docker. Friends don't let friends code their apps to
 // do app logging to files in containers.
 
-// Constants
-const PORT = process.env.PORT || 8080;
-// if you're not using docker-compose for local development, this will default to 8080
-// to prevent non-root permission problems with 80. Dockerfile is set to make this 80
-// because containers don't have that issue :)
-
 // Appi
 var app = express();
 
@@ -33,46 +27,5 @@ app.get('/healthz', function (req, res) {
 	// if you want, you should be able to restrict this to localhost (include ipv4 and ipv6)
   res.send('I am happy and healthy\n');
 });
-
-var server = app.listen(PORT, function () {
-  console.log('Webserver is ready');
-});
-
-
-//
-// need this in docker container to properly exit since node doesn't handle SIGINT/SIGTERM
-// this also won't work on using npm start since:
-// https://github.com/npm/npm/issues/4603
-// https://github.com/npm/npm/pull/10868
-// https://github.com/RisingStack/kubernetes-graceful-shutdown-example/blob/master/src/index.js
-// if you want to use npm then start with `docker run --init` to help, but I still don't think it's
-// a graceful shutdown of node process
-//
-
-// quit on ctrl-c when running docker in terminal
-process.on('SIGINT', function onSigint () {
-	console.info('Got SIGINT (aka ctrl-c in docker). Graceful shutdown ', new Date().toISOString());
-  shutdown();
-});
-
-// quit properly on docker stop
-process.on('SIGTERM', function onSigterm () {
-  console.info('Got SIGTERM (docker container stop). Graceful shutdown ', new Date().toISOString());
-  shutdown();
-})
-
-// shut down server
-function shutdown() {
-  server.close(function onServerClosed (err) {
-    if (err) {
-      console.error(err);
-      process.exitCode = 1;
-		}
-		process.exit();
-  })
-}
-//
-// need above in docker container to properly exit
-//
 
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "version": "2.0.0",
   "description": "Node.js Hello world app using docker features for easy docker-compose local dev and solid production defaults",
   "author": "Bret Fisher <bret@bretfisher.com>",
-  "main": "index.js",
+  "main": "bin/www",
   "scripts": {
-    "start": "node index.js",
+    "start": "node bin/www",
     "dev-docker": "../node_modules/nodemon/bin/nodemon.js --debug=5858",
     "dev-host": "nodemon --debug=5858",
-    "start-watch": "nodemon index.js --inspect=0.0.0.0:9229",
-    "start-wait-debuger": "nodemon index.js --inspect-brk=0.0.0.0:9229",
+    "start-watch": "nodemon bin/www --inspect=0.0.0.0:9229",
+    "start-wait-debuger": "nodemon bin/www --inspect-brk=0.0.0.0:9229",
     "test": "cross-env NODE_ENV=test PORT=8081 mocha --timeout 10000 --exit --inspect=0.0.0.0:9230",
     "test-watch": "nodemon --exec \"npm test\"",
     "test-wait-debuger": "cross-env NODE_ENV=test PORT=8081 mocha --no-timeouts --exit --inspect-brk=0.0.0.0:9230"


### PR DESCRIPTION
Hi, that's my first contribution.

Express V4 recommends isolating the startup scripts on a `./bin/www` file.

Source: https://expressjs.com/en/guide/migrating-4.html

Amazing repository, btw!
