### PR TITLE
Added graceful shutdown support

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -10,7 +10,7 @@ const PORT = process.env.PORT || 8080;
 // because containers don't have that issue :)
 
 var server = app.listen(PORT, function () {
-    console.log('Webserver is ready');
+    console.log(`Webserver is ready and listening on port ${PORT}`);
   });
   
 //
@@ -35,13 +35,37 @@ process.on('SIGTERM', function onSigterm () {
   shutdown();
 })
 
+let sockets = {}, nextSocketId = 0;
+server.on('connection', function (socket) {
+  const socketId = nextSocketId++;
+  sockets[socketId] = socket;
+
+  socket.once('close', function() {
+    delete sockets[socketId];
+  });
+});
+
 // shut down server
 function shutdown() {
+  waitForSocketsToClose(10);
+
   server.close(function onServerClosed (err) {
     if (err) {
       console.error(err);
       process.exitCode = 1;
-		}
-		process.exit();
-  })
+    }
+    process.exit();
+  });
+}
+
+function waitForSocketsToClose(counter) {
+  if (counter > 0) {
+    console.log(`Waiting ${counter} more ${counter === 1 ? 'seconds' : 'second'} for all connections to close...`);
+    return setTimeout(waitForSocketsToClose, 1000, counter - 1);
+  }
+  
+  console.log("Forcing all connections to close now");
+  for (var socketId in sockets) {
+    sockets[socketId].destroy();
+  }
 }


### PR DESCRIPTION
Happy Hacktoberfest! 😄 

Pretty much ripped off the example you posted that linked to the [SO article you provided](https://stackoverflow.com/questions/14626636/how-do-i-shutdown-a-node-js-https-server-immediately). 

One thing to note... the `server.close` method stops accepting new connections once called, but the callback isn't notified until all connections have been closed (see https://nodejs.org/api/net.html#net_server_close_callback).

Enjoy! Resolves #17 
