### PR TITLE
Correct the healthcheck test command for mongo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - MONGO_INITDB_ROOT_PASSWORD=example
       - MONGO_INITDB_DATABASE=example-database
     healthcheck:
-      test: echo 'db.stats().ok' | mongo localhost:27017/example-database --quiet
+      test: "[ `echo 'db.runCommand(\"ping\").ok' | mongo localhost/example-database --quiet` ] && echo 0 || echo 1"
       interval: 5s
       start_period: 10s
       timeout: 4s


### PR DESCRIPTION
Currently the db.stats().ok command returns 0 but it also returns an error message
```
root@2a08464c5256:/# echo 'db.stats().ok' | mongo localhost:27017/example-database --quiet 
0
root@2a08464c5256:/# echo 'db.stats()' | mongo localhost:27017/example-database --quiet
{
	"ok" : 0,
	"errmsg" : "command dbStats requires authentication",
	"code" : 13,
	"codeName" : "Unauthorized"
}
```
I have also updated to use the ping command as it returns even when the database is write-locked - see: https://docs.mongodb.com/manual/reference/command/ping/