### PR TITLE
Fix broken vscode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "protocol": "inspector",
             "port": 9229,
             "localRoot": "${workspaceRoot}",
-            "remoteRoot": "/opt/app"
+            "remoteRoot": "/opt/node_app/app"
         },
         {
             "name": "Docker Test (Attach 9230 --inspect)",
@@ -17,7 +17,7 @@
             "protocol": "inspector",
             "port": 9230,
             "localRoot": "${workspaceRoot}",
-            "remoteRoot": "/opt/app",
+            "remoteRoot": "/opt/node_app/app",
             "preLaunchTask": "Docker npm run test-wait-debuger", // See ./tasks.json
             "internalConsoleOptions": "openOnSessionStart"
         }


### PR DESCRIPTION
Hi, 

I guess through changing the the volume path in the `docker-compose.yml` from former `opt/app` to `opt/node_app/app` the vscode `launch.json` config is broken. This should fix it.