### PR TITLE
Correct the healthcheck test command for mongo in docker-swarm

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -33,7 +33,7 @@ services:
       - mongo_root
       - mongo_root_password
     healthcheck:
-      test: echo 'db.stats().ok' | mongo localhost:27017/example-database --quiet
+      test: "[ `echo 'db.runCommand(\"ping\").ok' | mongo localhost/example-database --quiet` ] && echo 0 || echo 1"
       interval: 5s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
This is the same command as for #52 but this config file was missed in that pull request