### PR TITLE
NPM manifests should be owned by node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ RUN mkdir /opt/node_app && chown node:node /opt/node_app
 WORKDIR /opt/node_app
 # the official node image provides an unprivileged user as a security best practice
 # but we have to manually enable it. We put it here so npm installs dependencies as the same
-# user who runs the app. 
+# user who runs the app.
 # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user
 USER node
-COPY package.json package-lock.json* ./
+COPY --chown=node:node package.json package-lock.json* ./
 RUN npm install --no-optional && npm cache clean --force
 ENV PATH /opt/node_app/node_modules/.bin:$PATH
 


### PR DESCRIPTION
Related to #79

We copy package*.json files as user root, but run npm as user node. I think we want to copy as user `node`, right?

(And I think NPM 7 is having issues with the mixed ownership, throwing EACCESS errors)