### PR TITLE
fix: avoid perm errors by making node_modules access unprivileged

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If this was your Node.js app, to start local development you would:
  - Be sure to use `docker-compose down` to cleanup after your done dev'ing.
 
 If you wanted to add a package while docker-compose was running your app:
- - `docker-compose exec -w /opt/node_app node npm install --save <package name>`
+ - `docker-compose exec node npm install --save <package name>`
  - This installs it inside the running container.
  - Nodemon will detect the change and restart.
  - `--save` will add it to the package.json for next `docker-compose build`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,14 +22,6 @@ services:
       - "9230:9230"
     volumes:
       - .:/opt/node_app/app
-      # bind-mounting these two files in will let you add packages during development without rebuilding
-      # for example, to add bower to your app while developing, just install it inside the container
-      # and then nodemon will restart. Your changes will last until you "docker-compose down" and will
-      # be saved on host for next build
-      # NOTE: this won't work on Docker Toolbox (virtualbox) which doesn't bind-mount single files
-      # docker-compose exec node npm install --save bower
-      - ./package.json:/opt/node_app/package.json
-      - ./package-lock.json:/opt/node_app/package-lock.json
       # this is a workaround to prevent host node_modules from accidently getting mounted in container
       # in case you want to use node/npm both outside container for test/lint etc. and also inside container
       # this will overwrite the default node_modules dir in container so it won't conflict with our


### PR DESCRIPTION
Allows packages to be installed via `docker-compose exec <service> npm i <package>`
closes #91. See #49 for the original discussion.
May also affect #28 by removing the need for individual file mounts as mentioned in the comments there, but it needs to be tested on Docker Toolbox/hyper-v to be sure.

Something to keep in mind is that this change makes the named volume (`notused` in compose) persist the results of the command above. removing volumes when needed (`docker-compose down -v`), or mounting an unnamed volume since it behaves like tmpfs mounts for our purposes (`:/opt/node_app/app/node_modules`), solves this case.

Also apologies for the late PR, life gets in the way :smile: 