### PR TITLE
Using npm@latest-7 and disabling git line ending conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.sh text eol=lf
+* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-* binary
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ EXPOSE $PORT 9229 9230
 
 # you'll likely want the latest npm, regardless of node version, for speed and fixes
 # but pin this version for the best stability
-RUN npm i npm@latest -g
+RUN npm i npm@latest-7 -g
 
 # install dependencies first, in a different location for easier app bind mounting for local development
 # due to default /opt permissions we have to create the dir with root and change perms


### PR DESCRIPTION
The container doesn't seem to run with npm@latest (tried on a Windows host and a WSL Ubuntu host), latest-7 solved it for me. Also, line ending conversion was enabled on Windows by default which was causing an error with the bash script running, the conversion can be disabled with the .gitattributes file. The container is running on both Windows and WSL Ubuntu host after these tweaks.